### PR TITLE
fix(js/rules.ts): turn off old rule space-before-function-paren

### DIFF
--- a/src/astro-ts/index.config.ts
+++ b/src/astro-ts/index.config.ts
@@ -13,7 +13,7 @@ const astroTsConfig = [
       parser: 'astro-eslint-parser',
       plugins: ['@typescript-eslint'],
       rules: {
-        '@typescript-eslint/strict-boolean-expressions': 0
+        '@typescript-eslint/strict-boolean-expressions': 'off'
       }
     }]
   }))

--- a/src/astro/index.config.ts
+++ b/src/astro/index.config.ts
@@ -18,8 +18,8 @@ const astroConfig = [
         'mdx/language-mapper': {}
       },
       rules: {
-        'max-len': 0,
-        'react/react-in-jsx-scope': 0
+        'max-len': 'off',
+        'react/react-in-jsx-scope': 'off'
       }
     }]
   }))

--- a/src/js/index.config.ts
+++ b/src/js/index.config.ts
@@ -43,7 +43,7 @@ const jsConfig: FlatConfig.ConfigArray = [
     rules: {
       ...configStandard.rules,
       ...pluginSonarJs.configs.recommended.rules,
-      'import/first': 0
+      'import/first': 'off'
     }
   },
   {

--- a/src/js/rules.ts
+++ b/src/js/rules.ts
@@ -43,17 +43,17 @@ const rules: Linter.RulesRecord = {
   '@stylistic/member-delimiter-style': ['error', {
     multiline: {
       delimiter: 'none',
-      requireLast: true
+      requireLast: false
     },
     singleline: {
       delimiter: 'comma',
-      requireLast: true
+      requireLast: false
     },
     overrides: {
       interface: {
         multiline: {
           delimiter: 'none',
-          requireLast: true
+          requireLast: false
         }
       }
     }
@@ -134,7 +134,8 @@ const rules: Linter.RulesRecord = {
   'no-useless-constructor': 'warn',
   'no-new': 'warn',
   'prefer-regex-literals': 'warn',
-  '@stylistic/multiline-comment-style': 'off'
+  '@stylistic/multiline-comment-style': 'off',
+  'space-before-function-paren': ['warn', 'never']
 }
 
 export { rules, groups }

--- a/src/js/rules.ts
+++ b/src/js/rules.ts
@@ -135,7 +135,7 @@ const rules: Linter.RulesRecord = {
   'no-new': 'warn',
   'prefer-regex-literals': 'warn',
   '@stylistic/multiline-comment-style': 'off',
-  'space-before-function-paren': ['warn', 'never']
+  'space-before-function-paren': 'off'
 }
 
 export { rules, groups }

--- a/src/next-ts/index.config.ts
+++ b/src/next-ts/index.config.ts
@@ -1,9 +1,15 @@
 import { nextConfig } from '../next/index.config.ts'
 import { reactTsConfig } from '../react-ts/index.config.ts'
 
+import { rules } from './rules.ts'
+
 const nextTsConfig = [
   ...reactTsConfig,
-  ...nextConfig
+  ...nextConfig,
+  {
+    name: 'custom-next-ts',
+    rules
+  }
 ]
 
 export { nextTsConfig }

--- a/src/next-ts/rules.ts
+++ b/src/next-ts/rules.ts
@@ -1,8 +1,8 @@
 import { groups } from '../js/rules.ts'
-import { rules as reactRules } from '../react/rules.ts'
+import { rules as reacTsRules } from '../react/rules.ts'
 
 const rules = {
-  ...reactRules,
+  ...reacTsRules,
   'simple-import-sort/imports': [
     'warn',
     {

--- a/src/react-ts/index.config.ts
+++ b/src/react-ts/index.config.ts
@@ -1,9 +1,15 @@
 import { reactConfig } from '../react/index.config.ts'
 import { tsConfig } from '../ts/index.config.ts'
 
+import { rules } from './rules.ts'
+
 const reactTsConfig = [
   ...reactConfig,
-  ...tsConfig
+  ...tsConfig,
+  {
+    name: 'custom-react-ts',
+    rules
+  }
 ]
 
 export { reactTsConfig }

--- a/src/react-ts/rules.ts
+++ b/src/react-ts/rules.ts
@@ -1,0 +1,9 @@
+import { rules as reactRules } from '../react/rules.ts'
+import { rules as tsRules } from '../ts/rules.ts'
+
+const rules = {
+  ...tsRules,
+  ...reactRules
+}
+
+export { rules }

--- a/src/ts/rules.ts
+++ b/src/ts/rules.ts
@@ -2,7 +2,7 @@ import { rules as jsRules } from '../js/rules.ts'
 
 const rules = {
   ...jsRules,
-  '@typescript-eslint/indent': 0,
+  '@typescript-eslint/indent': 'off',
   '@typescript-eslint/no-unused-vars': [
     'warn',
     {


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to eslint-config-santi020k! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

# Overview

[fix(js/rules.ts): turn off old rule space-before-function-paren](https://github.com/santi020k/eslint-config-santi020k/commit/f9aabe2dae1edfadb7be2ff9fe2be787efb879ed)
[fix(src/*): fix rule overwrite order](https://github.com/santi020k/eslint-config-santi020k/commit/cf00b9b90e87c69c031556db500a82545084b6eb)

## Type of Change

<!-- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

## Demo

N/A

## How Has This Been Tested?

N/A

## Checklist

- [X] I have performed a self-review of my own code
- [X] I have commented on my code, particularly in areas to understand
